### PR TITLE
Clamp features before applying log1p

### DIFF
--- a/dataset/graph_dataset_gen.py
+++ b/dataset/graph_dataset_gen.py
@@ -126,7 +126,11 @@ def _mp_worker_graph_generation_task(
         X_processed = X_features_full_window[:, :, :-1].clone()
 
         for k_feature_idx in range(X_processed.shape[0]):
-            X_processed[k_feature_idx] = torch.Tensor(np.log1p(X_processed[k_feature_idx].numpy()))
+            # Clamp values to avoid log1p producing -inf or NaN when data
+            # contains values <= -1. 1e-6 is used as a tiny epsilon so the
+            # minimum passed to log1p is (-1 + epsilon).
+            clamped_vals = torch.clamp(X_processed[k_feature_idx], min=-1 + 1e-6)
+            X_processed[k_feature_idx] = torch.log1p(clamped_vals)
             # Z-score normalization removed to match demo notebook more closely for now
             # mean = X_processed[k_feature_idx].mean(dim=1, keepdim=True)
             # std = X_processed[k_feature_idx].std(dim=1, keepdim=True)

--- a/train/train_val_test.py
+++ b/train/train_val_test.py
@@ -260,8 +260,12 @@ else:
         fitted_scaler = None
         selected_feature_idx = None
     else:
-        # Apply log1p transformation, similar to how it's done per window before scaling
-        log1p_training_features_np = np.log1p(training_features_np)
+        # Apply log1p transformation with clamping to avoid NaN/inf when any
+        # feature value is <= -1. Values are clipped to (-1 + epsilon) before
+        # applying log1p so the transformation remains finite.
+        epsilon = 1e-6
+        training_features_clamped = np.clip(training_features_np, a_min=-1 + epsilon, a_max=None)
+        log1p_training_features_np = np.log1p(training_features_clamped)
         
         # Initialize and fit the StandardScaler
         scaler = StandardScaler()


### PR DESCRIPTION
## Summary
- prevent NaNs in log1p by clamping features in graph generation
- apply the same clamping when fitting the global scaler

## Testing
- `python -m py_compile dataset/graph_dataset_gen.py train/train_val_test.py`