### PR TITLE
Fix MTGNN input dimension mismatch

### DIFF
--- a/train/train_val_test.py
+++ b/train/train_val_test.py
@@ -585,7 +585,9 @@ def train_batch(batch_sample, model, criterion, optimizer, device, scaler, use_a
     Processes a single batch of training data.
     """
     if use_mtgnn:
-        X = batch_sample['X_mtgnn'].to(device).permute(0, 3, 1, 2)
+        # X_mtgnn is stored as (Batch, NumNodes, Window, Features)
+        # MTGNN expects input in (Batch, NumNodes, Features, Window)
+        X = batch_sample['X_mtgnn'].to(device).permute(0, 1, 3, 2)
         A = None
     else:
         X = batch_sample['X'].to(device)
@@ -894,7 +896,9 @@ for epoch in range(epochs):
         with torch.no_grad():
             for i_val, val_sample in enumerate(val_loader):
                 if args.model.lower() == 'mtgnn':
-                    X_val = val_sample['X_mtgnn'].to(device).permute(0, 3, 1, 2)
+                    # Stored as (Batch, NumNodes, Window, Features)
+                    # Convert to (Batch, NumNodes, Features, Window) for MTGNN
+                    X_val = val_sample['X_mtgnn'].to(device).permute(0, 1, 3, 2)
                     A_val = None
                 else:
                     X_val = val_sample['X'].to(device)
@@ -1015,7 +1019,9 @@ else:
     with torch.no_grad():
         for i_test, test_sample in enumerate(test_loader):
             if args.model.lower() == 'mtgnn':
-                X_test = test_sample['X_mtgnn'].to(device).permute(0, 3, 1, 2)
+                # Stored as (Batch, NumNodes, Window, Features)
+                # Convert to (Batch, NumNodes, Features, Window) for MTGNN
+                X_test = test_sample['X_mtgnn'].to(device).permute(0, 1, 3, 2)
                 A_test = None
             else:
                 X_test = test_sample['X'].to(device)


### PR DESCRIPTION
## Summary
- align MTGNN training data permutation with the model expectation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*